### PR TITLE
Update ALB SSL policy

### DIFF
--- a/helm/templates/ingress.yaml
+++ b/helm/templates/ingress.yaml
@@ -13,6 +13,7 @@ metadata:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}, {"HTTPS": 443}]'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }}
     alb.ingress.kubernetes.io/ssl-redirect: '{"Type": "redirect", "RedirectConfig": {"Protocol": "HTTPS", "Port": "443", "StatusCode": "HTTP_301"}}'
+    alb.ingress.kubernetes.io/ssl-policy: ELBSecurityPolicy-TLS13-1-3-2021-06
     alb.ingress.kubernetes.io/success-codes: 200,404,301,302
     {{- include "ala-events.labels" . | nindent 4 }}
 spec:


### PR DESCRIPTION
Only updating the policy since the tags change will have to wait until the helm values file construction is refactored into the export_config_buildspec