### PR TITLE
Remove custom HTTP keepalive agent from Elasticsearch client

### DIFF
--- a/packages/es2vt/package-lock.json
+++ b/packages/es2vt/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "@elastic/elasticsearch": "7.17.0",
-        "agentkeepalive": "^4.2.0",
         "body-parser": "1.19.1",
         "command-line-args": "^5.2.0",
         "compression": "1.7.4",
@@ -76,19 +75,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/agentkeepalive": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
-      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
-      "dependencies": {
-        "debug": "^4.1.0",
-        "depd": "^1.1.2",
-        "humanize-ms": "^1.2.1"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
       }
     },
     "node_modules/ansi-align": {
@@ -1026,14 +1012,6 @@
       },
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-      "dependencies": {
-        "ms": "^2.0.0"
       }
     },
     "node_modules/iconv-lite": {
@@ -2196,16 +2174,6 @@
         "negotiator": "0.6.3"
       }
     },
-    "agentkeepalive": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.2.1.tgz",
-      "integrity": "sha512-Zn4cw2NEqd+9fiSVWMscnjyQ1a8Yfoc5oBajLeo5w+YBHgDUcEBY2hS4YpTz6iN5f/2zQiktcuM6tS8x1p9dpA==",
-      "requires": {
-        "debug": "^4.1.0",
-        "depd": "^1.1.2",
-        "humanize-ms": "^1.2.1"
-      }
-    },
     "ansi-align": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
@@ -2914,14 +2882,6 @@
         "setprototypeof": "1.2.0",
         "statuses": ">= 1.5.0 < 2",
         "toidentifier": "1.0.1"
-      }
-    },
-    "humanize-ms": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
-      "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
-      "requires": {
-        "ms": "^2.0.0"
       }
     },
     "iconv-lite": {

--- a/packages/es2vt/package.json
+++ b/packages/es2vt/package.json
@@ -10,16 +10,15 @@
   "license": "ISC",
   "dependencies": {
     "@elastic/elasticsearch": "7.17.0",
-    "agentkeepalive": "^4.2.0",
     "body-parser": "1.19.1",
     "command-line-args": "^5.2.0",
     "compression": "1.7.4",
     "express": "4.17.2",
     "lodash": "4.17.21",
-    "qs": "6.10.3",
-    "yaml": "1.10.2",
     "lru-cache": "^4.1.3",
-    "object-hash": "^1.3.0"
+    "object-hash": "^1.3.0",
+    "qs": "6.10.3",
+    "yaml": "1.10.2"
   },
   "devDependencies": {
     "nodemon": "^2.0.2"

--- a/packages/es2vt/src/resources/event/index.js
+++ b/packages/es2vt/src/resources/event/index.js
@@ -9,6 +9,7 @@ const client = new Client({
   nodes: env.event.hosts,
   maxRetries: env.event.maxRetries || 3,
   requestTimeout: env.event.requestTimeout || 60000,
+  keepAlive: true,
   auth: {
     username: env.event.username,
     password: env.event.password

--- a/packages/es2vt/src/resources/event/index.js
+++ b/packages/es2vt/src/resources/event/index.js
@@ -1,25 +1,14 @@
 // const elasticsearch = require('elasticsearch');
 const { Client } = require('@elastic/elasticsearch');
-const Agent = require('agentkeepalive');
 const { searchMvt } = require('../esRequest');
 const env = require('../../config');
 
 const searchIndex = env.event.index || 'event';
 
-// this isn't an ideal solution, but we keep changing between using an http and https agent. vonfig should require code change as well
-const isHttpsEndpoint = env.event.hosts[0].startsWith('https');
-const AgentType = isHttpsEndpoint ? Agent.HttpsAgent : Agent;
-
-const agent = () => new AgentType({
-  maxSockets: 1000, // Default = Infinity
-  keepAlive: true
-});
-
 const client = new Client({
   nodes: env.event.hosts,
   maxRetries: env.event.maxRetries || 3,
   requestTimeout: env.event.requestTimeout || 60000,
-  agent,
   auth: {
     username: env.event.username,
     password: env.event.password


### PR DESCRIPTION
Fixes `es2vt` crashes (& subsequent events instability) by removing the custom keepalive agent for the Elasticsearch client.