### PR TITLE
Add seedbank extension mapping to event reducer

### DIFF
--- a/packages/es-api/src/resources/event/event.config.js
+++ b/packages/es-api/src/resources/event/event.config.js
@@ -204,6 +204,17 @@ const config =
         }
       }
     },
+    catalogNumber: {
+      join: 'occurrence',
+      config: {
+        options: {
+          catalogNumber: {
+            type: 'keyword',
+            field: 'occurrence.catalogNumber.keyword'
+          }
+        }
+      }
+    },
     created: {
       type: 'date',
       field: 'created',
@@ -698,6 +709,102 @@ const config =
     metadata_publishingOrganizationKey: {
       type: 'keyword',
       field: 'metadata.publishingOrganizationKey'
+    },
+    seedbank_seedPerGram: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.seedPerGram',
+    },
+    seedbank_quantityInGrams: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.quantityInGrams',
+    },
+    seedbank_quantityCount: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.quantityCount',
+    },
+    seedbank_purityPercentage: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.purityPercentage',
+    },
+    seedbank_dateCollected: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.dateCollected',
+    },
+    seedbank_dateInStorage: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.dateInStorage',
+    },
+    seedbank_storageTemperatureInCelsius: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.storageTemperatureInCelsius',
+    },
+    seedbank_storageRelativeHumidityPercentage: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.storageRelativeHumidityPercentage',
+    },
+    seedbank_thousandSeedWeight: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.thousandSeedWeight',
+    },
+    seedbank_numberPlantsSampled: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.numberPlantsSampled',
+    },
+    seedbank_testDateStarted: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.testDateStarted',
+    },
+    seedbank_testLengthInDays: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.testLengthInDays',
+    },
+    seedbank_numberGerminated: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.numberGerminated',
+    },
+    seedbank_germinationRateInDays: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.germinationRateInDays',
+    },
+    seedbank_adjustedGerminationPercentage: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.adjustedGerminationPercentage',
+    },
+    seedbank_viabilityPercentage: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.viabilityPercentage',
+    },
+    seedbank_numberFull: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.numberFull',
+    },
+    seedbank_numberEmpty: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.numberEmpty',
+    },
+    seedbank_numberTested: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.numberTested',
+    },
+    seedbank_numberNotViable: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.numberNotViable',
+    },
+    seedbank_nightTemperatureInCelsius: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.nightTemperatureInCelsius',
+    },
+    seedbank_dayTemperatureInCelsius: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.dayTemperatureInCelsius',
+    },
+    seedbank_darkHours: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.darkHours',
+    },
+    seedbank_lightHours: {
+      type: 'numeric',
+      field: 'event.seedbankRecord.lightHours',
     },
     occurrence: {
       type: 'join',

--- a/packages/es-api/src/resources/event/reduce.js
+++ b/packages/es-api/src/resources/event/reduce.js
@@ -10,8 +10,75 @@ function removeUndefined(obj) {
  */
 function reduce(item) {
   const source = item._source;
-  const event = {...source.event, ...source.metadata, ...source.derivedMetadata};
-  return removeUndefined(event);
+  const { event } = source;
+
+  // Additional event verbatim fields
+  const eventVerbatim = removeUndefined({
+    eventRemarks: source.verbatim.core['http://rs.tdwg.org/dwc/terms/eventRemarks']
+  });
+
+  // Handle seedbank extension
+  let seedbankRecord;
+  const seedbankExtension = source.verbatim.extensions?.['http://ala.org.au/terms/seedbank/0.1/SeedbankRecord'];
+
+  // Ensure the seed bank extension exists before mapping the verbatim values
+  if (seedbankExtension) {
+    const [seedbankVerbatim] = seedbankExtension;
+    seedbankRecord = removeUndefined({
+      id:                                 event.seedbankRecord?.id,
+      eventID:                            seedbankVerbatim['http://rs.tdwg.org/dwc/terms/eventID'],
+      degreeOfEstablishment:              seedbankVerbatim['http://rs.tdwg.org/dwc/terms/degreeOfEstablishment'],
+      accessionNumber:                    seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/accessionNumber'],
+      herbariumVoucher:                   seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/herbariumVoucher'],
+      seedPerGram:                        event.seedbankRecord?.seedPerGram,
+      formInStorage:                      seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/formInStorage'],
+      quantityInGrams:                    event.seedbankRecord?.quantityInGrams,
+      quantityCount:                      event.seedbankRecord?.quantityCount,
+      purityPercentage:                   event.seedbankRecord?.purityPercentage,
+      dateCollected:                      event.seedbankRecord?.dateCollected,
+      dateInStorage:                      event.seedbankRecord?.dateInStorage,
+      storageTemperatureInCelsius:        event.seedbankRecord?.storageTemperatureInCelsius,
+      storageRelativeHumidityPercentage:  event.seedbankRecord?.storageRelativeHumidityPercentage,
+      publicationDOI:                     seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/publicationDOI'],
+      preStorageTreatment:                seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/preStorageTreatment'],
+      primaryStorageSeedBank:             seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/primaryStorageSeedBank'],
+      primaryCollector:                   seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/primaryCollector'],
+      plantForm:                          seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/plantForm'],
+      duplicatesReplicates:               seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/duplicatesReplicates'],
+      collectionPermitNumber:             seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/collectionPermitNumber'],
+      thousandSeedWeight:                 event.seedbankRecord?.thousandSeedWeight,
+      numberPlantsSampled:                event.seedbankRecord?.numberPlantsSampled,
+      storageBehaviour:                   seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/storageBehaviour'],
+      esRatio:                         seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/esRatio'],
+      dormancyClass:                      seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/dormancyClass'],
+      testDateStarted:                    event.seedbankRecord?.testDateStarted,
+      testLengthInDays:                   event.seedbankRecord?.testLengthInDays,
+      collectionFill:                     seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/collectionFill'],
+      numberGerminated:                   event.seedbankRecord?.numberGerminated,
+      germinationRateInDays:              event.seedbankRecord?.germinationRateInDays,
+      adjustedGerminationPercentage:      event.seedbankRecord?.adjustedGerminationPercentage,
+      viabilityPercentage:                event.seedbankRecord?.viabilityPercentage,
+      numberFull:                         event.seedbankRecord?.numberFull,
+      numberEmpty:                        event.seedbankRecord?.numberEmpty,
+      numberTested:                       event.seedbankRecord?.numberTested,
+      numberNotViable:                    event.seedbankRecord?.numberNotViable,
+      preTestProcessingNotes:             seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/preTestProcessingNotes'],
+      pretreatment:                       seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/pretreatment'],
+      mediaSubstrate:                     seedbankVerbatim['http://ala.org.au/terms/seedbank/0.1/mediaSubstrate'],
+      nightTemperatureInCelsius:          event.seedbankRecord?.nightTemperatureInCelsius,
+      dayTemperatureInCelsius:            event.seedbankRecord?.dayTemperatureInCelsius,
+      darkHours:                          event.seedbankRecord?.darkHours,
+      lightHours:                         event.seedbankRecord?.lightHours,
+    });
+  }
+
+  return removeUndefined({
+    ...source.event,
+    ...source.metadata,
+    ...source.derivedMetadata,
+    ...eventVerbatim,
+    seedbankRecord
+  });
 }
 
 module.exports = {


### PR DESCRIPTION
Updates the event reducer to include verbatim fields and detailed mapping for the seedbank extension when present.