### PR TITLE
Add optional chaining to dataset.methods check

### DIFF
--- a/packages/react-components/src/entities/EventDatasetSidebar/EventDatasetSidebar.js
+++ b/packages/react-components/src/entities/EventDatasetSidebar/EventDatasetSidebar.js
@@ -133,7 +133,7 @@ export function EventDatasetSidebar({
                       {dataset.citation}
                     </V>
                   </>}
-                  {dataset?.methods.length > 0 && <>
+                  {dataset?.methods?.length > 0 && <>
                     <T>Methods</T>
                     {dataset.methods.map((method, i) => {
                       if (typeof method !== 'object') return <V>Unspecified</V>;


### PR DESCRIPTION
Prevents potential null/undefined reference errors by adding optional chaining operator before accessing the `length` property of `dataset.methods`.